### PR TITLE
fix(frontend): Envolve a aplicação com BrowserRouter para corrigir er…

### DIFF
--- a/maintenance_system/maintenance-frontend/src/main.jsx
+++ b/maintenance_system/maintenance-frontend/src/main.jsx
@@ -1,13 +1,16 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.jsx'
 import { AuthProvider } from './context/AuthContext'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <AuthProvider>
-      <App />
-    </AuthProvider>
+    <BrowserRouter>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </BrowserRouter>
   </StrictMode>,
 )

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,13 +1,14 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import path from 'path'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(),tailwindcss()],
   resolve: {
     alias: {
-      "@": new URL('./src', import.meta.url).pathname,
+      "@": path.resolve(__dirname, "./src"),
     },
   },
 })


### PR DESCRIPTION
…ro de navegação

A aplicação estava exibindo uma página em branco devido ao erro "Uncaught Error: useNavigate() may be used only in the context of a <Router> component."

Este erro ocorria porque o componente AuthProvider utiliza o hook useNavigate, mas não era renderizado dentro de um <BrowserRouter>.

Esta alteração envolve toda a aplicação com o <BrowserRouter> dentro do arquivo main.jsx, fornecendo o contexto de roteamento necessário e resolvendo o erro.